### PR TITLE
Change loops over to low game events

### DIFF
--- a/megaphonepolice.lua
+++ b/megaphonepolice.lua
@@ -1,41 +1,30 @@
 local QBCore = exports['qb-core']:GetCoreObject()
-local inacopcar = false
+local inVeh = false
 
-
-CreateThread(function()
-        while true do
-            local ped = PlayerPedId()
-            if IsPedInAnyVehicle(ped) then
-                if not inacopcar then
-                    local PlayerJob = QBCore.Functions.GetPlayerData().job.name
-                    local vehicle = GetVehiclePedIsIn(ped)
-                    local vehicleClass = GetVehicleClass(vehicle)
-                    if DoesEntityExist(vehicle) and vehicleClass == 18 and PlayerJob == 'police' then
-                        StartListeningForControlmegaphone()
-                        inacopcar = true
-                    end
-                end
-            else
-                inacopcar = false
-                listentokey = false
-            end
-            Wait(1000)
-        end
+AddEventHandler('gameEventTriggered', function(name, args)
+if name == "CEventNetworkPlayerEnteredVehicle" then
+    local PlayerJob = QBCore.Functions.GetPlayerData().job.name
+    local vehicle = tonumber(args[2])
+    local vehicleClass = GetVehicleClass(vehicle)
+    if DoesEntityExist(vehicle) and vehicleClass == 18 and PlayerJob == 'police' then
+        inVeh = true
+    end
+end
 end)
 
-
-function StartListeningForControlmegaphone()
-	listentokey = true
-	CreateThread(function()
-		while listentokey do
-			if IsControlJustPressed(0, 61) then 
-				exports["pma-voice"]:overrideProximityRange(30.0, true)
-                QBCore.Functions.Notify('Megaphone on', 'success')
-            elseif IsControlJustReleased(0, 61) then 
-                exports["pma-voice"]:clearProximityOverride()
-                QBCore.Functions.Notify('Megaphone off', 'error')
-			end
-			Wait(1)
-		end
-	end)
+--https://cookbook.fivem.net/2020/01/06/using-the-new-console-key-bindings/
+RegisterCommand('+Megaphone', function()
+if inVeh then
+    exports["pma-voice"]:overrideProximityRange(30.0, true)
+    QBCore.Functions.Notify('Megaphone on', 'success')
 end
+end, false)
+
+RegisterCommand('-Megaphone', function()
+ if inVeh then
+	exports["pma-voice"]:clearProximityOverride()
+	QBCore.Functions.Notify('Megaphone off', 'error')
+ end
+end, false)
+
+RegisterKeyMapping('+Megaphone', 'Talk on the Megaphone', 'keyboard', 'LSHIFT')

--- a/megaphonepolice.lua
+++ b/megaphonepolice.lua
@@ -1,30 +1,32 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local inVeh = false
 
+
 AddEventHandler('gameEventTriggered', function(name, args)
-if name == "CEventNetworkPlayerEnteredVehicle" then
-    local PlayerJob = QBCore.Functions.GetPlayerData().job.name
+  if name == "CEventNetworkPlayerEnteredVehicle" then
     local vehicle = tonumber(args[2])
     local vehicleClass = GetVehicleClass(vehicle)
-    if DoesEntityExist(vehicle) and vehicleClass == 18 and PlayerJob == 'police' then
-        inVeh = true
+    if DoesEntityExist(vehicle) and vehicleClass == 18 then
+      inVeh = true
     end
-end
+  end
 end)
 
 --https://cookbook.fivem.net/2020/01/06/using-the-new-console-key-bindings/
 RegisterCommand('+Megaphone', function()
-if inVeh then
+  local PlayerJob = QBCore.Functions.GetPlayerData().job.name
+  if inVeh and PlayerJob == "police" then
     exports["pma-voice"]:overrideProximityRange(30.0, true)
     QBCore.Functions.Notify('Megaphone on', 'success')
-end
+  end
 end, false)
 
 RegisterCommand('-Megaphone', function()
- if inVeh then
-	exports["pma-voice"]:clearProximityOverride()
-	QBCore.Functions.Notify('Megaphone off', 'error')
- end
+  local PlayerJob = QBCore.Functions.GetPlayerData().job.name
+  if inVeh and PlayerJob == "police" then
+    exports["pma-voice"]:clearProximityOverride()
+    QBCore.Functions.Notify('Megaphone off', 'error')
+  end
 end, false)
 
 RegisterKeyMapping('+Megaphone', 'Talk on the Megaphone', 'keyboard', 'LSHIFT')


### PR DESCRIPTION
Hi as always the best you can do is test first, this version is using low game events, this event "CEventNetworkPlayerEnteredVehicle" only get triggered when you get in a vehicle, the first argument is the player (PlayerPedId()) and the second one is the vehicle, also im using KeyMapping to delete the other while loop, if you want to ask something JericoFX#3512.
Have a nice day!