### PR TITLE
Update megaphonepolice.lua

### DIFF
--- a/megaphonepolice.lua
+++ b/megaphonepolice.lua
@@ -1,29 +1,34 @@
 local QBCore = exports['qb-core']:GetCoreObject()
-local inVeh = false
+local PlayerData = {}
 
-
-AddEventHandler('gameEventTriggered', function(name, args)
-  if name == "CEventNetworkPlayerEnteredVehicle" then
-    local vehicle = tonumber(args[2])
-    local vehicleClass = GetVehicleClass(vehicle)
-    if DoesEntityExist(vehicle) and vehicleClass == 18 then
-      inVeh = true
-    end
-  end
+RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
+  PlayerData = val
 end)
+
+local function CheckPlayer()
+  local Player = PlayerPedId()
+  local getVehiclePedIsIn = GetVehiclePedIsIn(Player, false) > 0 and GetVehiclePedIsIn(Player, false) or 0 -- Get the vehicle the ped is in, if is > than 0 means the player is in a vehicle
+  if getVehiclePedIsIn == 0 then return end
+
+  local vehicleClass = GetVehicleClass(getVehiclePedIsIn) == 18 and true or false --get the class of it
+  if not vehicleClass then
+    QBCore.Functions.Notify("Ped not in a Police Vehicle", "error", 3000)
+    return
+  end
+
+  return vehicleClass
+end
 
 --https://cookbook.fivem.net/2020/01/06/using-the-new-console-key-bindings/
 RegisterCommand('+Megaphone', function()
-  local PlayerJob = QBCore.Functions.GetPlayerData().job.name
-  if inVeh and PlayerJob == "police" then
+  if PlayerData.job.name == "police" and CheckPlayer() then
     exports["pma-voice"]:overrideProximityRange(30.0, true)
     QBCore.Functions.Notify('Megaphone on', 'success')
   end
 end, false)
 
 RegisterCommand('-Megaphone', function()
-  local PlayerJob = QBCore.Functions.GetPlayerData().job.name
-  if inVeh and PlayerJob == "police" then
+  if PlayerData.job.name == "police" and CheckPlayer() then
     exports["pma-voice"]:clearProximityOverride()
     QBCore.Functions.Notify('Megaphone off', 'error')
   end


### PR DESCRIPTION
*fix: The game event only work when the player is in the vehicle but never when the player is out, so i modify everything to check when the player click the LSHIFT will do all the checks.
If you restart the script, set the job again
1)- if the player is in a vehicle or not.
2)- if the vehicle class is 18.
3) - if the job is X